### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "express-handlebars": "^3.1.0",
     "method-override": "^3.0.0",
     "mongoose": "^5.5.12",
-    "nodemon": "^1.19.1",
-    "npm": "^6.9.0"
+    "nodemon": "^1.19.1"
   }
 }


### PR DESCRIPTION

Hello mayank-m-sharma!

It seems like you have npm as one of your (dev-) dependency in cma_12.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
